### PR TITLE
Moved ErrorBoundary to avoid reload

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,44 +17,20 @@ pub fn App() -> impl IntoView {
     provide_meta_context();
 
     view! {
-
-        // injects info into HTML tag from application code
-        <Html
-            lang="en"
-            dir="ltr"
-            attr:data-theme="light"
-        />
+        <Html lang="en" dir="ltr" attr:data-theme="light"/>
 
         // sets the document title
         <Title text="Welcome to Leptos CSR"/>
 
         // injects metadata in the <head> of the page
-        <Meta charset="UTF-8" />
-        <Meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <Meta charset="UTF-8"/>
+        <Meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 
-
-        <ErrorBoundary
-            fallback=|errors| view! {
-                <h1>"Uh oh! Something went wrong!"</h1>
-
-                <p>"Errors: "</p>
-                // Render a list of errors as strings - good for development purposes
-                <ul>
-                    {move || errors.get()
-                        .into_iter()
-                        .map(|(_, e)| view! { <li>{e.to_string()}</li>})
-                        .collect_view()
-                    }
-                </ul>
-            }
-        >
-            <Router>
-                <Routes>
-                    <Route path="/" view=Home />
-                    <Route path="/*" view=NotFound />
-                </Routes>
-            </Router>
-
-        </ErrorBoundary>
+        <Router>
+            <Routes>
+                <Route path="/" view=Home/>
+                <Route path="/*" view=NotFound/>
+            </Routes>
+        </Router>
     }
 }

--- a/src/pages/home.rs
+++ b/src/pages/home.rs
@@ -5,37 +5,48 @@ use leptos::*;
 #[component]
 pub fn Home() -> impl IntoView {
     view! {
-                <ErrorBoundary
-            fallback=|errors| view! {
+        <ErrorBoundary fallback=|errors| {
+            view! {
                 <h1>"Uh oh! Something went wrong!"</h1>
 
                 <p>"Errors: "</p>
                 // Render a list of errors as strings - good for development purposes
                 <ul>
-                    {move || errors.get()
-                        .into_iter()
-                        .map(|(_, e)| view! { <li>{e.to_string()}</li>})
-                        .collect_view()
-                    }
+                    {move || {
+                        errors
+                            .get()
+                            .into_iter()
+                            .map(|(_, e)| view! { <li>{e.to_string()}</li> })
+                            .collect_view()
+                    }}
+
                 </ul>
             }
-        >
+        }>
 
-        <div class="container">
+            <div class="container">
 
-            <picture>
-                <source srcset="https://raw.githubusercontent.com/leptos-rs/leptos/main/docs/logos/Leptos_logo_pref_dark_RGB.svg" media="(prefers-color-scheme: dark)" />
-                <img src="https://raw.githubusercontent.com/leptos-rs/leptos/main/docs/logos/Leptos_logo_RGB.svg" alt="Leptos Logo" height="200" width="400"/>
-            </picture>
+                <picture>
+                    <source
+                        srcset="https://raw.githubusercontent.com/leptos-rs/leptos/main/docs/logos/Leptos_logo_pref_dark_RGB.svg"
+                        media="(prefers-color-scheme: dark)"
+                    />
+                    <img
+                        src="https://raw.githubusercontent.com/leptos-rs/leptos/main/docs/logos/Leptos_logo_RGB.svg"
+                        alt="Leptos Logo"
+                        height="200"
+                        width="400"
+                    />
+                </picture>
 
-            <h1>"Welcome to Leptos"</h1>
+                <h1>"Welcome to Leptos"</h1>
 
-            <div class="buttons">
-                <Button />
-                <Button increment=5 />
+                <div class="buttons">
+                    <Button/>
+                    <Button increment=5/>
+                </div>
+
             </div>
-
-        </div>
         </ErrorBoundary>
     }
 }

--- a/src/pages/home.rs
+++ b/src/pages/home.rs
@@ -5,6 +5,22 @@ use leptos::*;
 #[component]
 pub fn Home() -> impl IntoView {
     view! {
+                <ErrorBoundary
+            fallback=|errors| view! {
+                <h1>"Uh oh! Something went wrong!"</h1>
+
+                <p>"Errors: "</p>
+                // Render a list of errors as strings - good for development purposes
+                <ul>
+                    {move || errors.get()
+                        .into_iter()
+                        .map(|(_, e)| view! { <li>{e.to_string()}</li>})
+                        .collect_view()
+                    }
+                </ul>
+            }
+        >
+
         <div class="container">
 
             <picture>
@@ -20,5 +36,6 @@ pub fn Home() -> impl IntoView {
             </div>
 
         </div>
+        </ErrorBoundary>
     }
 }


### PR DESCRIPTION
Attempt at fixing  leptos-rs/leptos#2361 by moving the errorboundary to the home element, now it doesn't cause a reload when submitting a form, the minimum reproduction example is in the mentioned issue 