### PR TITLE
Bugfix: remove rel="stylesheet"

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <!-- Add a plain CSS file: see https://trunkrs.dev/assets/#css -->
     <!-- If using Tailwind with Leptos CSR, see https://trunkrs.dev/assets/#tailwind instead-->
-    <link data-trunk rel="css" rel="stylesheet" href="public/styles.css" />
+    <link data-trunk rel="css" href="public/styles.css" />
 
     <!-- Include favicon in dist output: see https://trunkrs.dev/assets/#icon -->
     <link data-trunk rel="icon" href="public/favicon.ico" />


### PR DESCRIPTION
Otherwise it doesn't build:

``` cargo generate --git https://github.com/leptos-community/start-csr
cd fubar
trunk serve --port 3000 --open

2024-05-06T05:50:09.573268Z  INFO :rocket: Starting trunk 0.20.0
2024-05-06T05:50:09.576434Z  INFO :package: starting build
2024-05-06T05:50:09.711597Z ERROR :x: error
error from build pipeline

Caused by:
    unknown <link data-trunk .../> attr value `rel="stylesheet"`; please ensure the value is lowercase and is a supported asset type```