### PR TITLE
fix: typo in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <!-- Add a plain CSS file: see https://trunkrs.dev/assets/#css -->
     <!-- If using Tailwind with Leptos CSR, see https://trunkrs.dev/assets/#tailwind instead-->
-    <link data-trunk rel="css" rel="stylesheet" href="public/styles.css" />
+    <link data-trunk rel="css" href="public/styles.css" />
 
     <!-- Include favicon in dist output: see https://trunkrs.dev/assets/#icon -->
     <link data-trunk rel="icon" href="public/favicon.ico" />


### PR DESCRIPTION
there are two "rel" attributes in link, only one with value of "css" should be there