### PR TITLE
fix fallback/404 view for router

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod pages;
 
 // Top-Level pages
 use crate::pages::home::Home;
+use crate::pages::not_found::NotFound;
 
 /// An app router which renders the homepage and handles 404's
 #[component]
@@ -26,7 +27,7 @@ pub fn App() -> impl IntoView {
         <Meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
         <Router>
-            <Routes fallback=|| view! { NotFound }>
+            <Routes fallback=|| view! { <NotFound /> }>
                 <Route path=path!("/") view=Home />
             </Routes>
         </Router>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub fn App() -> impl IntoView {
         <Meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
         <Router>
-            <Routes fallback=|| view! { <NotFound /> }>
+            <Routes fallback=NotFound>
                 <Route path=path!("/") view=Home />
             </Routes>
         </Router>


### PR DESCRIPTION

On a fresh project, going to a non-existent page just returns the text `NotFound` as body instead of the `<NotFound />` component; fixed here.