### PR TITLE
fix: mark favicon as exclude

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,5 +1,6 @@
 [template]
 ignore = ["Cargo.lock", "switch_nightly_stable.rhai"]
+exclude = ["public/favicon.ico"]
 
 [placeholders]
 default_channel = { prompt = "Use stable or nightly channel?", choices = [


### PR DESCRIPTION
Hey dude, I'm using `cargo-generate` of version `0.23.0`, which will cause this error:

![image](https://github.com/user-attachments/assets/fc899839-b410-4202-aed9-3669abdca67f)

I'm not sure what is undergoing but if we check the content of `public/favicon.ico` as plain-text file with `rg -a` (or `grep` in similary way), there are `{`s paired with `}`s, which may be wrongly recognized as liquid templates.

Below is the according situation in the unit test of `cargo-generate`:

https://github.com/cargo-generate/cargo-generate/blob/ee0400ff0211b4937b5d341b05e513587d8f330f/tests/integration/template_filters.rs#L33-L59

This PR can solve it. I'm not sure if it's `cargo-generate`'s bug, but I'd like to make this template work well first ❤️ 